### PR TITLE
fix: bumps js package version

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formbricks/js",
   "license": "MIT",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Formbricks-js allows you to connect your index to Formbricks, display surveys and trigger events.",
   "homepage": "https://formbricks.com",
   "repository": {


### PR DESCRIPTION
Bumps the js package version to `v4.2.0` for the next release