### PR TITLE
fix: backports the repo url fix

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://formbricks.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/formbricks/formbricks"
+    "url": "https://github.com/formbricks/js"
   },
   "keywords": [
     "Formbricks",


### PR DESCRIPTION
backports the repo url fix in the js package's package.json file which got merged into the main with https://github.com/formbricks/js/pull/13