### PR TITLE
chore: bumps sdk version to 4.4.0

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formbricks/js",
   "license": "MIT",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Formbricks-js allows you to connect your index to Formbricks, display surveys and trigger events.",
   "homepage": "https://formbricks.com",
   "repository": {


### PR DESCRIPTION
bumps js sdk version to `4.4.0`